### PR TITLE
Document the dependency on PyXDG

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ Dependencies
 - [lxml](http://lxml.de)
 - [Progressbar](https://code.google.com/p/python-progressbar)
 - [Python Keyring Lib](https://bitbucket.org/kang/python-keyring-lib)
+- [PyXDG](https://freedesktop.org/wiki/Software/pyxdg/)
 
 The above can be installed in any modern Debian-like distros (like Ubuntu/Mint) with:
 
-	sudo apt-get install python-{lxml,progressbar,keyring}
+	sudo apt-get install python-{lxml,progressbar,keyring,xdg}
 
 
 Install


### PR DESCRIPTION
I just cloned the repo and couldn't run humblebundle.py because of a missing lib.
I suggest we add it to the README.
